### PR TITLE
Return q in order to give external access to the queue

### DIFF
--- a/src/traverse-async.coffee
+++ b/src/traverse-async.coffee
@@ -29,4 +29,4 @@ exports.traverse = (data, userCallback, done) ->
 
   q.push { node: data, path: [], isRoot: true }
 
-  q
+  break: q.kill


### PR DESCRIPTION
I'd like to be able to kill the queue on an error, but its not accessible. Maybe return 'q' in export.traverse instead of returning q.push, which is undefined?
