### PR TITLE
add access to queue.push

### DIFF
--- a/src/traverse-async.coffee
+++ b/src/traverse-async.coffee
@@ -30,3 +30,4 @@ exports.traverse = (data, userCallback, done) ->
   q.push { node: data, path: [], isRoot: true }
 
   break: q.kill
+  push: q.push


### PR DESCRIPTION
use case is for editing a node in-place and re-queuing the updated node.
